### PR TITLE
Power curve save data reminder

### DIFF
--- a/code/+mpqc/+record/power.m
+++ b/code/+mpqc/+record/power.m
@@ -575,20 +575,13 @@ classdef power < handle
         function windowCloseFcn(obj,~,~)
             if obj.wasSaved == false
                 saveBox = questdlg('Do you want to save data?', 'Save Data', 'Save','Close without saving','Save');
-                switch saveBox
-                    case 'Save'
-                        obj.saveData
-                        disp('Saved')
-                        obj.delete % simply call the destructor
-                    case 'Close without saving'
-                        disp('Not saved')
-                        obj.delete % simply call the destructor
+                if strcmp(saveBox,'Save')
+                    obj.saveData
+                    disp('Saved')
                 end
-            else
-                obj.delete % simply call the destructor
             end
+            obj.delete % Close the GUI and tidy up
         end
-
     end % hidden methods
 
 end % classdef

--- a/code/+mpqc/+record/power.m
+++ b/code/+mpqc/+record/power.m
@@ -107,6 +107,8 @@ classdef power < handle
         %   .laserWavelength
         %   .fittedMinAndMax
 
+        wasSaved = false;
+
     end % properties
 
     properties (Hidden)
@@ -467,6 +469,7 @@ classdef power < handle
 
             obj.enableButtons;
 
+            obj.wasSaved = false;
         end % recordPowerCurve
 
 
@@ -501,6 +504,7 @@ classdef power < handle
 
             % Report where the file was saved
             mpqc.tools.reportFileSaveLocation(saveDir,fileName)
+            obj.wasSaved = true;
         end % saveData_Callback
 
 
@@ -569,25 +573,20 @@ classdef power < handle
         end % disableButtons
 
         function windowCloseFcn(obj,~,~)
-            saveBox = questdlg('Do you want to save data?', 'Save Data', 'Save','Close without saving','Save')
-            switch saveBox
-                case 'Save'
-                    disp('Saved')
-                    obj.delete % simply call the destructor
-                case 'Close without saving'
-                    disp('Not saved')
-                    obj.delete % simply call the destructor
+            if obj.wasSaved == false
+                saveBox = questdlg('Do you want to save data?', 'Save Data', 'Save','Close without saving','Save');
+                switch saveBox
+                    case 'Save'
+                        obj.saveData
+                        disp('Saved')
+                        obj.delete % simply call the destructor
+                    case 'Close without saving'
+                        disp('Not saved')
+                        obj.delete % simply call the destructor
+                end
+            else
+                obj.delete % simply call the destructor
             end
-            % This runs when the user closes the figure window.
-            % selection = uiconfirm(obj,"Do you want to save data?", "Save data");
-            % switch selection
-            %     case "Save"
-            %         saveData(obj,~,~)
-            %         obj.delete % simply call the destructor
-            %     case "Close without saving"
-            %         obj.delete % simply call the destructor
-            % end %close windowCloseFcn
-            % obj.delete % simply call the destructor
         end
 
     end % hidden methods

--- a/code/+mpqc/+record/power.m
+++ b/code/+mpqc/+record/power.m
@@ -570,9 +570,15 @@ classdef power < handle
 
         function windowCloseFcn(obj,~,~)
             % This runs when the user closes the figure window.
-
-            obj.delete % simply call the destructor
-        end %close windowCloseFcn
+            selection = uiconfirm(obj,"Do you want to save data?", "Save data");
+            switch selection
+                case "Save"
+                    saveData(obj,~,~)
+                    obj.delete % simply call the destructor
+                case "Close without saving"
+                    obj.delete % simply call the destructor
+            end %close windowCloseFcn
+        end
 
     end % hidden methods
 

--- a/code/+mpqc/+record/power.m
+++ b/code/+mpqc/+record/power.m
@@ -569,15 +569,25 @@ classdef power < handle
         end % disableButtons
 
         function windowCloseFcn(obj,~,~)
+            saveBox = questdlg('Do you want to save data?', 'Save Data', 'Save','Close without saving','Save')
+            switch saveBox
+                case 'Save'
+                    disp('Saved')
+                    obj.delete % simply call the destructor
+                case 'Close without saving'
+                    disp('Not saved')
+                    obj.delete % simply call the destructor
+            end
             % This runs when the user closes the figure window.
-            selection = uiconfirm(obj,"Do you want to save data?", "Save data");
-            switch selection
-                case "Save"
-                    saveData(obj,~,~)
-                    obj.delete % simply call the destructor
-                case "Close without saving"
-                    obj.delete % simply call the destructor
-            end %close windowCloseFcn
+            % selection = uiconfirm(obj,"Do you want to save data?", "Save data");
+            % switch selection
+            %     case "Save"
+            %         saveData(obj,~,~)
+            %         obj.delete % simply call the destructor
+            %     case "Close without saving"
+            %         obj.delete % simply call the destructor
+            % end %close windowCloseFcn
+            % obj.delete % simply call the destructor
         end
 
     end % hidden methods


### PR DESCRIPTION
If the power curve data has not been saved, a window pops up when closing the figure prompting the user to save the data. If data has already been saved, window does not pop up. Connected to issue #117 